### PR TITLE
Add a link to ACFUN-FOSS's C++ SDK

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,0 +1,2 @@
+# 未包含在此仓库内的 SDK
+- [C++](https://github.com/ACFUN-FOSS/acfun-cloud-emoji-sdk-cxx/)


### PR DESCRIPTION
不用 submodules 是因为 submodules 只能与固定的 commit 相链接。我们希望用户总是看到主分支上最新的内容。